### PR TITLE
Setup Aurora database in serverless.yml file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3583,6 +3583,12 @@
         "lodash.isempty": "^4.4.0"
       }
     },
+    "serverless-pseudo-parameters": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.5.0.tgz",
+      "integrity": "sha512-A/O49AR8LL6jlnPSmnOTYgL1KqVgskeRla4sVDeS/r5dHFJlwOU5MgFilc7aaQP8NWAwRJANaIS9oiSE3I+VUA==",
+      "dev": true
+    },
     "serverless-python-requirements": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/serverless-python-requirements/-/serverless-python-requirements-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "serverless-api-gateway-throttling": "^1.0.1"
   },
   "devDependencies": {
+    "serverless-pseudo-parameters": "^2.5.0",
     "serverless-python-requirements": "^5.0.1"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -37,6 +37,19 @@ custom:
   apiGatewayThrottling:
     maxRequestsPerSecond: 10
     maxConcurrentRequests: 20
+  # DB parameters
+  auroraUsername: postgres
+
+resources:
+  Resources:
+    auroraDbCredentials:
+      Type: AWS::SecretsManager::Secret
+      Properties:
+        Description: 'Credentails for the Aurora DB'
+        GenerateSecretString:
+            SecretStringTemplate: '{"username": "${self:custom.auroraUsername}"}'
+            GenerateStringKey: 'password'
+
 provider:
   name: aws
   runtime: python3.6

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: ">=1.1.0 <2.0.0"
 plugins:
   - serverless-python-requirements
   - serverless-api-gateway-throttling
+  - serverless-pseudo-parameters
 package:
   exclude:
     - node_modules/**
@@ -30,15 +31,15 @@ custom:
   stage: ${opt:stage, self:custom.default_stage}
   stack_name: ${self:custom.app_acronym}-${self:custom.stage}
   region: ${opt:region, self:provider.region}
-  aurora_cluster_arn: "arn:aws:rds:${self:custom.region}:472965085233:cluster:albion-serverless"
-  secret_arn: "arn:aws:secretsmanager:${self:custom.region}:472965085233:secret:prod/camelot/albion-serverless-iINkbR"
+  aurora:
+    username: postgres
+    cluster_identifier: albion-serverless
+    cluster_arn: "arn:aws:rds:#{AWS::Region}:#{AWS::AccountId}:cluster:${self:custom.aurora.cluster_identifier}" # CF doesn't expose this, so need to recreate it
   pythonRequirements:
     dockerizePip: non-linux 
   apiGatewayThrottling:
     maxRequestsPerSecond: 10
     maxConcurrentRequests: 20
-  # DB parameters
-  auroraUsername: postgres
 
 resources:
   Resources:
@@ -47,20 +48,20 @@ resources:
       Properties:
         Description: 'Credentails for the Aurora DB'
         GenerateSecretString:
-            SecretStringTemplate: '{"username": "${self:custom.auroraUsername}"}'
+            SecretStringTemplate: '{"username": "${self:custom.aurora.username}"}'
             GenerateStringKey: 'password'
             ExcludeCharacters: '"@/\'
     auroraDb:
       Type: AWS::RDS::DBCluster
       Properties:
         DatabaseName: tintagel
-        DBClusterIdentifier: albion-serverless
+        DBClusterIdentifier: ${self:custom.aurora.cluster_identifier}
         DBClusterParameterGroupName: default.aurora-postgresql10
         EnableHttpEndpoint: True
         Engine: aurora-postgresql
         EngineMode: serverless
         EngineVersion: '10.7'
-        MasterUsername: ${self:custom.auroraUsername}
+        MasterUsername: ${self:custom.aurora.username}
         MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref auroraDbCredentials, ':SecretString:password}}' ]]
         ScalingConfiguration:
           AutoPause: True
@@ -78,8 +79,8 @@ provider:
     restApi: true
   environment:
     REGION: ${self:custom.region}
-    AURORA_CLUSTER_ARN: ${self:custom.aurora_cluster_arn}
-    SECRET_ARN: ${self:custom.secret_arn}
+    AURORA_CLUSTER_ARN: ${self:custom.aurora.cluster_arn}
+    SECRET_ARN: !Ref auroraDbCredentials
 functions:
   add_player:
     handler: add_player.lambda_handler

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,6 +49,24 @@ resources:
         GenerateSecretString:
             SecretStringTemplate: '{"username": "${self:custom.auroraUsername}"}'
             GenerateStringKey: 'password'
+            ExcludeCharacters: '"@/\'
+    auroraDb:
+      Type: AWS::RDS::DBCluster
+      Properties:
+        DatabaseName: tintagel
+        DBClusterIdentifier: albion-serverless
+        DBClusterParameterGroupName: default.aurora-postgresql10
+        EnableHttpEndpoint: True
+        Engine: aurora-postgresql
+        EngineMode: serverless
+        EngineVersion: '10.7'
+        MasterUsername: ${self:custom.auroraUsername}
+        MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref auroraDbCredentials, ':SecretString:password}}' ]]
+        ScalingConfiguration:
+          AutoPause: True
+          MaxCapacity: 2
+          MinCapacity: 2
+          SecondsUntilAutoPause: 7200 # 120 minutes
 
 provider:
   name: aws

--- a/serverless.yml
+++ b/serverless.yml
@@ -68,6 +68,27 @@ resources:
           MaxCapacity: 2
           MinCapacity: 2
           SecondsUntilAutoPause: 7200 # 120 minutes
+    lambdaRdsPolicy:
+      Type: AWS::IAM::ManagedPolicy
+      Properties:
+        Description: 'IAM Policy to give lambdas access to RDS Data API'
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - 'rds-data:BatchExecuteStatement'
+                - 'rds-data:BeginTransaction'
+                - 'rds-data:CommitTransaction'
+                - 'rds-data:ExecuteStatement'
+                - 'rds-data:RollbackTransaction'
+              Resource: '*' # RDS Data API does not support resource-level permissions
+              # Also need secrets manager access to read DB password
+            - Effect: Allow
+              Action:
+                - 'secretsmanager:GetSecretValue'
+              Resource:
+                - !Ref auroraDbCredentials
 
 provider:
   name: aws
@@ -81,6 +102,9 @@ provider:
     REGION: ${self:custom.region}
     AURORA_CLUSTER_ARN: ${self:custom.aurora.cluster_arn}
     SECRET_ARN: !Ref auroraDbCredentials
+  iamManagedPolicies: # Give policies to all lambdas
+    - !Ref lambdaRdsPolicy
+
 functions:
   add_player:
     handler: add_player.lambda_handler


### PR DESCRIPTION
This PR adds creation of the following AWS resources:
1. password for the database in Secrets Manager
2. serverless Aurora database (dynamically resolves the password in CloudFormation)
3. IAM Policy for Lambda access to database and secrets manager ( closes #18 )

The ARNs for these resources are then properly linked into the lambdas.

After test deploying it to dev, everything seems to be working. Will file some follow up issues for more things to be added.
